### PR TITLE
perf(encode): pooled buffer, WriteByte fix, and Encode() fast paths

### DIFF
--- a/byteslice_writer.go
+++ b/byteslice_writer.go
@@ -1,0 +1,18 @@
+package msgpack
+
+// byteSliceWriter is a zero-allocation writer that appends directly to a
+// []byte buffer. It implements the writer interface (io.Writer + WriteByte).
+// Used by Marshal() to avoid allocating a bytes.Buffer on every call.
+type byteSliceWriter struct {
+	buf *[]byte
+}
+
+func (w *byteSliceWriter) Write(p []byte) (int, error) {
+	*w.buf = append(*w.buf, p...)
+	return len(p), nil
+}
+
+func (w *byteSliceWriter) WriteByte(c byte) error {
+	*w.buf = append(*w.buf, c)
+	return nil
+}

--- a/encode.go
+++ b/encode.go
@@ -1,7 +1,6 @@
 package msgpack
 
 import (
-	"bytes"
 	"io"
 	"reflect"
 	"sync"
@@ -26,16 +25,18 @@ type writer interface {
 
 type byteWriter struct {
 	io.Writer
+	scratch [1]byte
 }
 
-func newByteWriter(w io.Writer) byteWriter {
-	return byteWriter{
+func newByteWriter(w io.Writer) *byteWriter {
+	return &byteWriter{
 		Writer: w,
 	}
 }
 
-func (bw byteWriter) WriteByte(c byte) error {
-	_, err := bw.Write([]byte{c})
+func (bw *byteWriter) WriteByte(c byte) error {
+	bw.scratch[0] = c
+	_, err := bw.Write(bw.scratch[:])
 	return err
 }
 
@@ -53,29 +54,38 @@ func GetEncoder() *Encoder {
 
 func PutEncoder(enc *Encoder) {
 	enc.w = nil
+	// Keep wbuf capacity for reuse, but drop oversized buffers.
+	if cap(enc.wbuf) > 32*1024 {
+		enc.wbuf = nil
+	}
 	encPool.Put(enc)
 }
 
 // Marshal returns the MessagePack encoding of v.
 func Marshal(v interface{}) ([]byte, error) {
 	enc := GetEncoder()
-
-	var buf bytes.Buffer
-	enc.Reset(&buf)
+	enc.resetForMarshal()
 
 	err := enc.Encode(v)
-	b := buf.Bytes()
+
+	var b []byte
+	if err == nil {
+		b = make([]byte, len(enc.wbuf))
+		copy(b, enc.wbuf)
+	}
 
 	PutEncoder(enc)
 
 	if err != nil {
 		return nil, err
 	}
-	return b, err
+	return b, nil
 }
 
 type Encoder struct {
 	w         writer
+	bsw       byteSliceWriter // embedded writer for Marshal() path
+	wbuf      []byte          // reusable output buffer for Marshal()
 	dict      map[string]int
 	structTag string
 	buf       []byte
@@ -127,6 +137,17 @@ func (e *Encoder) ResetWriter(w io.Writer) {
 	} else {
 		e.w = newByteWriter(w)
 	}
+}
+
+// resetForMarshal sets up the encoder to write into the embedded wbuf,
+// avoiding bytes.Buffer allocation. Used exclusively by Marshal().
+func (e *Encoder) resetForMarshal() {
+	e.wbuf = e.wbuf[:0]
+	e.bsw.buf = &e.wbuf
+	e.w = &e.bsw
+	e.flags = 0
+	e.structTag = ""
+	e.dict = nil
 }
 
 // SetSortMapKeys causes the Encoder to encode map keys in increasing order.
@@ -222,8 +243,30 @@ func (e *Encoder) Encode(v interface{}) error {
 		return e.encodeInt64Cond(int64(v))
 	case time.Time:
 		return e.EncodeTime(v)
+	case map[string]interface{}:
+		if e.flags&sortMapKeysFlag != 0 {
+			return e.EncodeMapSorted(v)
+		}
+		return e.EncodeMap(v)
+	case []interface{}:
+		return e.encodeInterfaceSlice(v)
 	}
 	return e.EncodeValue(reflect.ValueOf(v))
+}
+
+func (e *Encoder) encodeInterfaceSlice(s []interface{}) error {
+	if s == nil {
+		return e.EncodeNil()
+	}
+	if err := e.EncodeArrayLen(len(s)); err != nil {
+		return err
+	}
+	for _, v := range s {
+		if err := e.Encode(v); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (e *Encoder) EncodeMulti(v ...interface{}) error {


### PR DESCRIPTION
Three encode-side optimizations:

1. Replace per-call bytes.Buffer in Marshal() with an embedded []byte buffer (wbuf) in the Encoder struct. Since encoders are pooled via sync.Pool, buffer capacity persists across calls. The new byteSliceWriter implements the writer interface with zero allocations and native WriteByte — eliminating both the bytes.Buffer alloc and the byteWriter.WriteByte []byte{c} alloc for the Marshal() path.

2. Fix byteWriter.WriteByte for the streaming NewEncoder(w) path to use a [1]byte scratch field instead of allocating []byte{c} per single-byte write.

3. Add map[string]interface{} and []interface{} fast paths to the Encode() type-switch, bypassing reflect.ValueOf + sync.Map lookup for Arc's most common Marshal payloads.

benchstat (5 runs, Apple M3 Max):
  Discard:                  -57% time, -100% mem (2→0 B/op), 2→0 allocs
  StructMarshal:            -12% time, -16% mem (1464→1224 B/op), 7→4 allocs
  StructVmihailencoMsgpack: -10% time, -16% mem, 14→11 allocs
  MapStringInterfaceMsgpack: -5% time
  Unmarshal benchmarks: unchanged (expected)