### PR TITLE
fix(decode): cap alloc limits and fix flag check for OOM safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## v6 (Basekick-Labs fork)
+
+### Performance
+
+- **decode:** zero-allocation byte-slice reader for `Unmarshal()` — replaces `bytes.NewReader` + `bufio.NewReader` with a direct `byteSliceReader`, eliminating 2 allocations per call (~21% faster decode, ~50% less memory)
+- **decode:** `*interface{}` fast path in `Decode()` — skips `reflect.ValueOf` for the most common `Unmarshal(b, &interface{})` pattern (~14% faster)
+- **encode:** pooled byte buffer in `Marshal()` — replaces per-call `bytes.Buffer` with a reusable `[]byte` embedded in the pooled `Encoder` struct
+- **encode:** `byteSliceWriter` for `Marshal()` path — native `WriteByte` implementation eliminates per-byte heap allocation
+- **encode:** `byteWriter.WriteByte` scratch fix for streaming path — uses `[1]byte` scratch instead of allocating `[]byte{c}`
+- **encode:** `Encode()` fast paths for `map[string]interface{}` and `[]interface{}` — bypasses `reflect.ValueOf` + sync.Map encoder lookup
+
+### Bug Fixes
+
+- **decode:** cap `decodeSlice()` allocation at `sliceAllocLimit` (1M) to prevent OOM from malicious payloads ([#1](https://github.com/Basekick-Labs/msgpack/issues/1))
+- **decode:** cap `DecodeMap()` allocation at `maxMapSize` (1M) — same OOM vector for `map[string]interface{}` path
+- **decode:** fix `disableAllocLimitFlag` check in `decodeSliceValue` — `!= 1` was always true because the flag value is `1 << 3 = 8`, so the alloc limit in `growSliceValue()` was never applied
+- **decode:** fix error message in `DecodeFloat64` — said "decoding float32" instead of "decoding float64" ([#13](https://github.com/Basekick-Labs/msgpack/issues/13))
+
+### Chores
+
+- Modernize GitHub Actions (checkout@v4, setup-go@v5)
+- Go version matrix: 1.25.x, 1.26.x
+- Bump `go.mod` to Go 1.26
+
+---
+
 ## [5.4.1](https://github.com/vmihailenco/msgpack/compare/v5.4.0...v5.4.1) (2023-10-26)
 
 

--- a/decode_map.go
+++ b/decode_map.go
@@ -157,7 +157,12 @@ func (d *Decoder) DecodeMap() (map[string]interface{}, error) {
 		return nil, nil
 	}
 
-	m := make(map[string]interface{}, n)
+	ln := n
+	if d.flags&disableAllocLimitFlag == 0 && ln > maxMapSize {
+		ln = maxMapSize
+	}
+
+	m := make(map[string]interface{}, ln)
 
 	for i := 0; i < n; i++ {
 		mk, err := d.DecodeString()

--- a/decode_number.go
+++ b/decode_number.go
@@ -213,7 +213,7 @@ func (d *Decoder) float64(c byte) (float64, error) {
 
 	n, err := d.int(c)
 	if err != nil {
-		return 0, fmt.Errorf("msgpack: invalid code=%x decoding float32", c)
+		return 0, fmt.Errorf("msgpack: invalid code=%x decoding float64", c)
 	}
 	return float64(n), nil
 }

--- a/decode_slice.go
+++ b/decode_slice.go
@@ -101,7 +101,7 @@ func decodeSliceValue(d *Decoder, v reflect.Value) error {
 		v.Set(v.Slice(0, v.Cap()))
 	}
 
-	noLimit := d.flags&disableAllocLimitFlag != 1
+	noLimit := d.flags&disableAllocLimitFlag != 0
 
 	if noLimit && n > v.Len() {
 		v.Set(growSliceValue(v, n, noLimit))
@@ -170,7 +170,12 @@ func (d *Decoder) decodeSlice(c byte) ([]interface{}, error) {
 		return nil, nil
 	}
 
-	s := make([]interface{}, 0, n)
+	allocN := n
+	if d.flags&disableAllocLimitFlag == 0 && allocN > sliceAllocLimit {
+		allocN = sliceAllocLimit
+	}
+
+	s := make([]interface{}, 0, allocN)
 	for i := 0; i < n; i++ {
 		v, err := d.decodeInterfaceCond()
 		if err != nil {


### PR DESCRIPTION
## Summary

- Cap `decodeSlice()` allocation at `sliceAllocLimit` (1M) to prevent OOM from malicious payloads claiming huge array lengths
- Cap `DecodeMap()` allocation at `maxMapSize` (1M) — same OOM vector for the `map[string]interface{}` path used by Arc's `*interface{}` fast path
- Fix `disableAllocLimitFlag` check in `decodeSliceValue` — `!= 1` was always true because the flag value is `1 << 3 = 8`, so `growSliceValue()` alloc limit was never applied
- Fix error message in `DecodeFloat64` — said "decoding float32" instead of "decoding float64"
- Add v6 changelog

Closes #1, closes #13.

## Test plan

- [x] `go test ./... -v -count=1` — all tests pass (except pre-existing upstream TestTypes panic, issue #21)
- [x] `go test -run='^$' -bench=. -benchmem -count=3` — zero performance regression