### PR TITLE
fix(decode): handle unaddressable values in interface decode

### DIFF
--- a/decode_value.go
+++ b/decode_value.go
@@ -182,7 +182,15 @@ func decodeInterfaceValue(d *Decoder, v reflect.Value) error {
 	if v.IsNil() {
 		return d.interfaceValue(v)
 	}
-	return d.DecodeValue(v.Elem())
+
+	elem := v.Elem()
+	if elem.Kind() == reflect.Ptr {
+		return d.DecodeValue(elem)
+	}
+
+	// Non-pointer values inside interfaces are not addressable.
+	// Decode a fresh value instead.
+	return d.interfaceValue(v)
 }
 
 func (d *Decoder) interfaceValue(v reflect.Value) error {


### PR DESCRIPTION
## Summary

- Fix panic "reflect.Value.SetInt using unaddressable value" when decoding into an `interface{}` that already holds a non-pointer value type (e.g. `int8`)
- `decodeInterfaceValue()` now checks if the inner value is a pointer before attempting in-place decode; falls back to fresh-value decode for value types
- This is the canonical fix for 5 upstream issues (#21, #29, #30, #31, #32)

Closes #21, closes #29, closes #30, closes #31, closes #32.

## Test plan

- [x] `go test -run TestTypes -count=10` — passes all 10 (previously panicked at count=5)
- [x] `go test ./... -v -count=1` — full suite passes
- [x] `go test ./... -short -race` — clean
- [x] `go test -run='^$' -bench=. -benchmem -count=3` — zero regression