### PR TITLE
fix(decode): support non-string map keys in interface{}

### DIFF
--- a/decode_map.go
+++ b/decode_map.go
@@ -52,7 +52,27 @@ func (d *Decoder) decodeMapDefault() (interface{}, error) {
 	if d.mapDecoder != nil {
 		return d.mapDecoder(d)
 	}
-	return d.DecodeMap()
+
+	n, err := d.DecodeMapLen()
+	if err != nil {
+		return nil, err
+	}
+	if n == -1 {
+		return nil, nil
+	}
+	if n == 0 {
+		return make(map[string]interface{}), nil
+	}
+
+	code, err := d.PeekCode()
+	if err != nil {
+		return nil, err
+	}
+
+	if msgpcode.IsString(code) {
+		return d.decodeMapStringInterfaceN(n)
+	}
+	return d.decodeTypedMapN(n)
 }
 
 // DecodeMapLen decodes map length. Length is -1 when map is nil.
@@ -152,11 +172,13 @@ func (d *Decoder) DecodeMap() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	if n == -1 {
 		return nil, nil
 	}
+	return d.decodeMapStringInterfaceN(n)
+}
 
+func (d *Decoder) decodeMapStringInterfaceN(n int) (map[string]interface{}, error) {
 	ln := n
 	if d.flags&disableAllocLimitFlag == 0 && ln > maxMapSize {
 		ln = maxMapSize
@@ -218,7 +240,10 @@ func (d *Decoder) DecodeTypedMap() (interface{}, error) {
 	if n <= 0 {
 		return nil, nil
 	}
+	return d.decodeTypedMapN(n)
+}
 
+func (d *Decoder) decodeTypedMapN(n int) (interface{}, error) {
 	key, err := d.decodeInterfaceCond()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Maps with non-string keys (e.g. `map[int]string`) failed to decode into `interface{}` because `decodeMapDefault()` unconditionally called `DecodeMap()`, which assumes string keys
- Now peeks at the first key's type code via `PeekCode()` and dispatches to the typed-map path (`decodeTypedMapN`) when keys are not strings
- Extracted `decodeMapStringInterfaceN(n)` and `decodeTypedMapN(n)` helpers to avoid duplicating logic across `DecodeMap()`, `DecodeTypedMap()`, and `decodeMapDefault()`

Fixes #5, fixes #17.

## Test plan

- [x] Full test suite passes (`go test ./... -count=1`)
- [x] Benchmarks show zero regression on string-keyed maps (~405 ns/op)
- [x] `map[int]string` round-trips correctly through `interface{}`