### PR TITLE
fix(decode): allow float-encoded values to decode into int64/uint64 (#2)

### DIFF
--- a/decode_number.go
+++ b/decode_number.go
@@ -87,6 +87,32 @@ func (d *Decoder) DecodeUint64() (uint64, error) {
 	return d.uint(c)
 }
 
+func floatToInt64(f float64) (int64, error) {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, fmt.Errorf("msgpack: cannot decode %v into int64", f)
+	}
+	if f != math.Trunc(f) {
+		return 0, fmt.Errorf("msgpack: cannot decode fractional float %v into int64", f)
+	}
+	if f > float64(math.MaxInt64) || f < float64(math.MinInt64) {
+		return 0, fmt.Errorf("msgpack: float %v overflows int64", f)
+	}
+	return int64(f), nil
+}
+
+func floatToUint64(f float64) (uint64, error) {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, fmt.Errorf("msgpack: cannot decode %v into uint64", f)
+	}
+	if f != math.Trunc(f) {
+		return 0, fmt.Errorf("msgpack: cannot decode fractional float %v into uint64", f)
+	}
+	if f < 0 || f > float64(math.MaxUint64) {
+		return 0, fmt.Errorf("msgpack: float %v overflows uint64", f)
+	}
+	return uint64(f), nil
+}
+
 func (d *Decoder) uint(c byte) (uint64, error) {
 	if c == msgpcode.Nil {
 		return 0, nil
@@ -115,6 +141,18 @@ func (d *Decoder) uint(c byte) (uint64, error) {
 		return uint64(n), err
 	case msgpcode.Uint64, msgpcode.Int64:
 		return d.uint64()
+	case msgpcode.Float:
+		n, err := d.float32(c)
+		if err != nil {
+			return 0, err
+		}
+		return floatToUint64(float64(n))
+	case msgpcode.Double:
+		n, err := d.float64(c)
+		if err != nil {
+			return 0, err
+		}
+		return floatToUint64(n)
 	}
 	return 0, fmt.Errorf("msgpack: invalid code=%x decoding uint64", c)
 }
@@ -158,6 +196,18 @@ func (d *Decoder) int(c byte) (int64, error) {
 	case msgpcode.Uint64, msgpcode.Int64:
 		n, err := d.uint64()
 		return int64(n), err
+	case msgpcode.Float:
+		n, err := d.float32(c)
+		if err != nil {
+			return 0, err
+		}
+		return floatToInt64(float64(n))
+	case msgpcode.Double:
+		n, err := d.float64(c)
+		if err != nil {
+			return 0, err
+		}
+		return floatToInt64(n)
 	}
 	return 0, fmt.Errorf("msgpack: invalid code=%x decoding int64", c)
 }

--- a/types_test.go
+++ b/types_test.go
@@ -1028,6 +1028,73 @@ func TestDecodeFloat32FromFloat64(t *testing.T) {
 	require.Error(t, msgpack.Unmarshal(b, &f))
 }
 
+func TestDecodeInt64FromFloat64(t *testing.T) {
+	// Issue #2: float64-encoded values (e.g. from JSON) should decode into int64/uint64.
+
+	t.Run("happy path", func(t *testing.T) {
+		// float64 -> int64
+		b, err := msgpack.Marshal(float64(10))
+		require.NoError(t, err)
+		var i int64
+		require.NoError(t, msgpack.Unmarshal(b, &i))
+		require.Equal(t, int64(10), i)
+
+		// float64 -> uint64
+		var u uint64
+		require.NoError(t, msgpack.Unmarshal(b, &u))
+		require.Equal(t, uint64(10), u)
+
+		// float32 -> int64
+		b, err = msgpack.Marshal(float32(42))
+		require.NoError(t, err)
+		require.NoError(t, msgpack.Unmarshal(b, &i))
+		require.Equal(t, int64(42), i)
+
+		// negative float64 -> int64
+		b, err = msgpack.Marshal(float64(-7))
+		require.NoError(t, err)
+		require.NoError(t, msgpack.Unmarshal(b, &i))
+		require.Equal(t, int64(-7), i)
+
+		// zero
+		b, err = msgpack.Marshal(float64(0))
+		require.NoError(t, err)
+		require.NoError(t, msgpack.Unmarshal(b, &i))
+		require.Equal(t, int64(0), i)
+	})
+
+	t.Run("errors", func(t *testing.T) {
+		// NaN -> int64
+		b, err := msgpack.Marshal(math.NaN())
+		require.NoError(t, err)
+		var i int64
+		require.Error(t, msgpack.Unmarshal(b, &i))
+
+		// NaN -> uint64
+		var u uint64
+		require.Error(t, msgpack.Unmarshal(b, &u))
+
+		// +Inf -> int64
+		b, _ = msgpack.Marshal(math.Inf(1))
+		require.Error(t, msgpack.Unmarshal(b, &i))
+
+		// -Inf -> uint64
+		b, _ = msgpack.Marshal(math.Inf(-1))
+		require.Error(t, msgpack.Unmarshal(b, &u))
+
+		// fractional -> int64
+		b, _ = msgpack.Marshal(3.14)
+		require.Error(t, msgpack.Unmarshal(b, &i))
+
+		// fractional -> uint64
+		require.Error(t, msgpack.Unmarshal(b, &u))
+
+		// negative float -> uint64
+		b, _ = msgpack.Marshal(float64(-1))
+		require.Error(t, msgpack.Unmarshal(b, &u))
+	})
+}
+
 func TestFloat32(t *testing.T) {
 	tests := []struct {
 		in     float32


### PR DESCRIPTION
When numbers pass through JSON (which decodes all numbers as float64), re-encoding with msgpack produces Double-coded values. Previously, DecodeInt64/DecodeUint64 rejected these codes. Now float32/float64 codes are accepted with validation: NaN, Inf, fractional values, and out-of-range conversions return clear errors instead of silently producing garbage.

Closes #2