### PR TITLE
fix(encode): preserve custom error types instead of reducing to strin…

### DIFF
--- a/encode_value.go
+++ b/encode_value.go
@@ -185,7 +185,25 @@ func encodeErrorValue(e *Encoder, v reflect.Value) error {
 	if v.IsNil() {
 		return e.EncodeNil()
 	}
+	// If the concrete type has a custom encoder, use it instead of reducing
+	// the error to a plain string.
+	elem := v.Elem()
+	typ := elem.Type()
+	if hasCustomEncoder(typ) {
+		return e.EncodeValue(elem)
+	}
 	return e.EncodeString(v.Interface().(error).Error())
+}
+
+func hasCustomEncoder(typ reflect.Type) bool {
+	if _, ok := typeEncMap.Load(typ); ok {
+		return true
+	}
+	if typ.Implements(customEncoderType) || typ.Implements(marshalerType) ||
+		typ.Implements(binaryMarshalerType) || typ.Implements(textMarshalerType) {
+		return true
+	}
+	return false
 }
 
 func encodeUnsupportedValue(e *Encoder, v reflect.Value) error {

--- a/types_test.go
+++ b/types_test.go
@@ -289,6 +289,41 @@ var encoderTests = []encoderTest{
 	{&Intern{A: "foo", B: "foo", C: "foo"}, "83a141a3666f6fa142d48000a143d48000"},
 }
 
+// Issue #22: custom error types should not be reduced to plain errors.
+type CustomError struct {
+	Code    int
+	Message string
+}
+
+func (e *CustomError) Error() string { return e.Message }
+
+func (e *CustomError) EncodeMsgpack(enc *msgpack.Encoder) error {
+	return enc.EncodeMulti(e.Code, e.Message)
+}
+
+func (e *CustomError) DecodeMsgpack(dec *msgpack.Decoder) error {
+	return dec.DecodeMulti(&e.Code, &e.Message)
+}
+
+func TestCustomErrorPreserved(t *testing.T) {
+	type Container struct {
+		Err error
+	}
+
+	orig := &Container{Err: &CustomError{Code: 404, Message: "not found"}}
+	b, err := msgpack.Marshal(orig)
+	require.NoError(t, err)
+
+	// The encoded data should not be a plain string — it should use the
+	// custom encoder. Verify by decoding the error field as interface{}.
+	var raw map[string]interface{}
+	err = msgpack.Unmarshal(b, &raw)
+	require.NoError(t, err)
+	// If the custom encoder was used, the value is an array [404, "not found"],
+	// not a plain string "not found".
+	require.NotEqual(t, "not found", raw["Err"], "custom error was reduced to plain string")
+}
+
 func TestEncoder(t *testing.T) {
 	var buf bytes.Buffer
 	enc := msgpack.NewEncoder(&buf)


### PR DESCRIPTION
…g (#22)

encodeErrorValue now checks if the concrete error type has a custom encoder (CustomEncoder, Marshaler, BinaryMarshaler, or TextMarshaler) or a registered encoder. If found, dispatches through EncodeValue to use the custom encoder. Standard errors (errors.New, fmt.Errorf) still fall back to .Error() string encoding.

Closes #22