### PR TITLE
fix(encode): respect non-zero unexported fields in omitempty check (#6)

### DIFF
--- a/types.go
+++ b/types.go
@@ -338,7 +338,19 @@ func (e *Encoder) isEmptyValue(v reflect.Value) bool {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
 		return v.Len() == 0
 	case reflect.Struct:
-		structFields := structs.Fields(v.Type(), e.structTag)
+		// Check unexported fields first — if any are non-zero the struct
+		// is not empty, even if all exported fields would be omitted.
+		typ := v.Type()
+		for i := 0; i < typ.NumField(); i++ {
+			sf := typ.Field(i)
+			if sf.PkgPath == "" || sf.Anonymous {
+				continue // exported or embedded — handled below
+			}
+			if !v.Field(i).IsZero() {
+				return false
+			}
+		}
+		structFields := structs.Fields(typ, e.structTag)
 		fields := structFields.OmitEmpty(e, v)
 		return len(fields) == 0
 	case reflect.Bool:

--- a/types_test.go
+++ b/types_test.go
@@ -1253,3 +1253,36 @@ func mustParseTime(format, s string) time.Time {
 	}
 	return tm
 }
+
+// Issue #6: omitempty should not omit structs with non-zero unexported fields.
+type structWithUnexported struct {
+	secret int
+	Pub    string `msgpack:",omitempty"`
+}
+
+type wrapperOmitEmpty struct {
+	Inner structWithUnexported `msgpack:",omitempty"`
+}
+
+func TestOmitEmptyUnexportedFields(t *testing.T) {
+	// Inner has a non-zero unexported field, so it must NOT be omitted.
+	w := wrapperOmitEmpty{Inner: structWithUnexported{secret: 42}}
+	b, err := msgpack.Marshal(w)
+	require.NoError(t, err)
+
+	var out map[string]interface{}
+	require.NoError(t, msgpack.Unmarshal(b, &out))
+	// "Inner" key must be present because the struct is not empty.
+	_, ok := out["Inner"]
+	require.True(t, ok, "Inner with non-zero unexported field should not be omitted")
+
+	// When both unexported and exported fields are zero, it should be omitted.
+	w2 := wrapperOmitEmpty{Inner: structWithUnexported{}}
+	b2, err := msgpack.Marshal(w2)
+	require.NoError(t, err)
+
+	var out2 map[string]interface{}
+	require.NoError(t, msgpack.Unmarshal(b2, &out2))
+	_, ok = out2["Inner"]
+	require.False(t, ok, "Inner with all zero fields should be omitted")
+}


### PR DESCRIPTION
## Summary
- Fixes #6: `omitempty` incorrectly omits structs with non-zero unexported fields
- Adds a check for non-zero unexported fields in `isEmptyValue` before evaluating exported fields
- Upstream: https://github.com/vmihailenco/msgpack/issues/378

## Test plan
- [x] New test `TestOmitEmptyUnexportedFields` validates structs with non-zero unexported fields are NOT omitted
- [x] Verifies structs with all-zero fields are still correctly omitted
- [x] Full test suite passes