### PR TITLE
fix(decode): use interface{} value type for non-string-keyed maps (#20)

### DIFF
--- a/decode_map.go
+++ b/decode_map.go
@@ -255,13 +255,14 @@ func (d *Decoder) decodeTypedMapN(n int) (interface{}, error) {
 	}
 
 	keyType := reflect.TypeOf(key)
-	valueType := reflect.TypeOf(value)
 
 	if !keyType.Comparable() {
 		return nil, fmt.Errorf("msgpack: unsupported map key: %s", keyType.String())
 	}
 
-	mapType := reflect.MapOf(keyType, valueType)
+	// Use interface{} as the value type so heterogeneous values (e.g.
+	// nested maps with different inner types) decode without type errors.
+	mapType := reflect.MapOf(keyType, interfaceType)
 
 	ln := n
 	if d.flags&disableAllocLimitFlag == 0 {

--- a/types_test.go
+++ b/types_test.go
@@ -1246,6 +1246,31 @@ func TestFloat64(t *testing.T) {
 	}
 }
 
+func TestNestedMapIntegerKeys(t *testing.T) {
+	// Issue #20: nested maps with integer keys should round-trip through interface{}.
+	m := map[int]map[int]interface{}{
+		1: {10: "hello", 20: 42},
+	}
+	b, err := msgpack.Marshal(m)
+	require.NoError(t, err)
+
+	var out interface{}
+	require.NoError(t, msgpack.Unmarshal(b, &out))
+	require.NotNil(t, out)
+
+	// Also test heterogeneous inner values across outer entries.
+	m2 := map[int]map[int]interface{}{
+		1: {10: "hello"},
+		2: {20: 42},
+	}
+	b2, err := msgpack.Marshal(m2)
+	require.NoError(t, err)
+
+	var out2 interface{}
+	require.NoError(t, msgpack.Unmarshal(b2, &out2))
+	require.NotNil(t, out2)
+}
+
 func mustParseTime(format, s string) time.Time {
 	tm, err := time.Parse(format, s)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fixes #20: Nested maps with integer keys could not decode into `interface{}`
- `decodeTypedMapN` inferred a rigid value type from the first map entry, causing failures when subsequent values had different concrete types
- Now uses `interface{}` as the value type, consistent with `decodeMapStringInterfaceN`
- Upstream: https://github.com/vmihailenco/msgpack/issues/314

## Test plan
- [x] New test `TestNestedMapIntegerKeys` with nested maps and heterogeneous inner values
- [x] Full test suite passes