### PR TITLE
fix(pool): drop oversized decoder buffers to prevent memory leak (#19)

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -46,7 +46,11 @@ func PutDecoder(dec *Decoder) {
 	dec.r = nil
 	dec.s = nil
 	dec.bsr.data = nil
-	if dec.buf != nil {
+	// Keep buf capacity for reuse, but drop oversized buffers to prevent
+	// the pool from retaining memory from large decode operations.
+	if cap(dec.buf) > 32*1024 {
+		dec.buf = nil
+	} else if dec.buf != nil {
 		dec.buf = dec.buf[:0]
 	}
 	decPool.Put(dec)

--- a/types_test.go
+++ b/types_test.go
@@ -1271,6 +1271,29 @@ func TestNestedMapIntegerKeys(t *testing.T) {
 	require.NotNil(t, out2)
 }
 
+func TestPoolReleasesOversizedBuffers(t *testing.T) {
+	// Issue #19: pooled encoders/decoders should not retain oversized buffers.
+	// Marshal then unmarshal a large payload; the pool should drop big buffers.
+	large := make([]byte, 64*1024) // 64KB > 32KB cap
+	for i := range large {
+		large[i] = byte(i)
+	}
+
+	b, err := msgpack.Marshal(large)
+	require.NoError(t, err)
+
+	var out []byte
+	require.NoError(t, msgpack.Unmarshal(b, &out))
+	require.Equal(t, large, out)
+
+	// A second marshal/unmarshal of a small value should work without issue.
+	b2, err := msgpack.Marshal("small")
+	require.NoError(t, err)
+	var s string
+	require.NoError(t, msgpack.Unmarshal(b2, &s))
+	require.Equal(t, "small", s)
+}
+
 func mustParseTime(format, s string) time.Time {
 	tm, err := time.Parse(format, s)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fixes #19: Pooled decoder buffers could grow unbounded after large decode operations
- `PutDecoder` now drops buffers exceeding 32KB, matching the existing `PutEncoder` behavior
- Upstream: https://github.com/vmihailenco/msgpack/issues/322

## Test plan
- [x] New test `TestPoolReleasesOversizedBuffers` with 64KB payload round-trip
- [x] Full test suite passes