### PR TITLE
perf(encode): add MarshalAppend for zero-alloc buffer reuse

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -304,6 +304,21 @@ func BenchmarkStructMarshal(b *testing.B) {
 	}
 }
 
+func BenchmarkStructMarshalAppend(b *testing.B) {
+	in := structForBenchmark()
+	buf := make([]byte, 0, 2048)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var err error
+		buf, err = msgpack.MarshalAppend(buf[:0], in)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func BenchmarkStructUnmarshal(b *testing.B) {
 	in := structForBenchmark()
 	buf, err := msgpack.Marshal(in)

--- a/encode.go
+++ b/encode.go
@@ -63,23 +63,26 @@ func PutEncoder(enc *Encoder) {
 
 // Marshal returns the MessagePack encoding of v.
 func Marshal(v interface{}) ([]byte, error) {
+	return MarshalAppend(nil, v)
+}
+
+// MarshalAppend is like Marshal but appends the encoded bytes to dst.
+// This allows callers to reuse buffers and reduce allocations:
+//
+//	buf = buf[:0]
+//	buf, err = msgpack.MarshalAppend(buf, v)
+func MarshalAppend(dst []byte, v interface{}) ([]byte, error) {
 	enc := GetEncoder()
 	enc.resetForMarshal()
 
-	err := enc.Encode(v)
-
-	var b []byte
-	if err == nil {
-		b = make([]byte, len(enc.wbuf))
-		copy(b, enc.wbuf)
+	if err := enc.Encode(v); err != nil {
+		PutEncoder(enc)
+		return dst, err
 	}
 
+	dst = append(dst, enc.wbuf...)
 	PutEncoder(enc)
-
-	if err != nil {
-		return nil, err
-	}
-	return b, nil
+	return dst, nil
 }
 
 type Encoder struct {


### PR DESCRIPTION
## Summary
- Adds `MarshalAppend(dst, v)` that appends encoded bytes to a caller-provided buffer, eliminating the final `make+copy` allocation in `Marshal()`
- Refactors `Marshal()` to delegate to `MarshalAppend(nil, v)` — behavior is identical
- Follows the standard Go `Append*` pattern (like `strconv.AppendInt`)

## Benchmark Results
```
BenchmarkStructMarshal-14         3139424    378.4 ns/op   1224 B/op   4 allocs/op
BenchmarkStructMarshalAppend-14   4091446    293.8 ns/op     72 B/op   3 allocs/op
```
**~26% faster, 94% less memory** when callers reuse a buffer.

## Test plan
- [x] All existing tests pass
- [x] New benchmark validates improvement