### PR TITLE
perf(encode): skip OmitEmpty slice allocation when no fields omitted

### DIFF
--- a/types.go
+++ b/types.go
@@ -159,8 +159,20 @@ func (fs *fields) OmitEmpty(e *Encoder, strct reflect.Value) []*field {
 		return fs.List
 	}
 
-	fields := make([]*field, 0, len(fs.List))
+	// First pass: count surviving fields. If all survive, return the
+	// original slice without allocating a filtered copy.
+	n := 0
+	for _, f := range fs.List {
+		if !f.Omit(e, strct) {
+			n++
+		}
+	}
+	if n == len(fs.List) {
+		return fs.List
+	}
 
+	// Second pass: build the filtered slice only when necessary.
+	fields := make([]*field, 0, n)
 	for _, f := range fs.List {
 		if !f.Omit(e, strct) {
 			fields = append(fields, f)


### PR DESCRIPTION
## Summary
- Two-pass `OmitEmpty`: first counts surviving fields, returns `fs.List` directly if all survive (zero allocs)
- Only allocates a filtered `[]*field` slice when fields are actually omitted
- Common fast path for time-series data where most struct fields have values

## Details
Before this change, every struct encode with `omitempty` tags (or `SetOmitEmpty(true)`) allocated a new `[]*field` slice even when no fields were empty. This is wasteful since the common case is all fields populated. The two-pass approach avoids this allocation entirely when no fields are omitted.

## Test plan
- [x] All existing tests pass (including TestSetOmitEmpty, TestOmitEmptyUnexportedFields)
- [x] Benchmarks verified — no regressions