### PR TITLE
perf(encode,decode): skip reflect.Convert for exact map/slice types

### DIFF
--- a/decode_map.go
+++ b/decode_map.go
@@ -114,7 +114,12 @@ func (d *Decoder) mapLen(c byte) (int, error) {
 }
 
 func decodeMapStringStringValue(d *Decoder, v reflect.Value) error {
-	mptr := v.Addr().Convert(mapStringStringPtrType).Interface().(*map[string]string)
+	var mptr *map[string]string
+	if v.Type() == mapStringStringType {
+		mptr = v.Addr().Interface().(*map[string]string)
+	} else {
+		mptr = v.Addr().Convert(mapStringStringPtrType).Interface().(*map[string]string)
+	}
 	return d.decodeMapStringStringPtr(mptr)
 }
 
@@ -154,7 +159,12 @@ func (d *Decoder) decodeMapStringStringPtr(ptr *map[string]string) error {
 }
 
 func decodeMapStringInterfaceValue(d *Decoder, v reflect.Value) error {
-	ptr := v.Addr().Convert(mapStringInterfacePtrType).Interface().(*map[string]interface{})
+	var ptr *map[string]interface{}
+	if v.Type() == mapStringInterfaceType {
+		ptr = v.Addr().Interface().(*map[string]interface{})
+	} else {
+		ptr = v.Addr().Convert(mapStringInterfacePtrType).Interface().(*map[string]interface{})
+	}
 	return d.decodeMapStringInterfacePtr(ptr)
 }
 

--- a/decode_slice.go
+++ b/decode_slice.go
@@ -7,7 +7,10 @@ import (
 	"github.com/vmihailenco/msgpack/v5/msgpcode"
 )
 
-var sliceStringPtrType = reflect.TypeOf((*[]string)(nil))
+var (
+	sliceStringPtrType = reflect.TypeOf((*[]string)(nil))
+	sliceStringType    = sliceStringPtrType.Elem()
+)
 
 // DecodeArrayLen decodes array length. Length is -1 when array is nil.
 func (d *Decoder) DecodeArrayLen() (int, error) {
@@ -36,7 +39,12 @@ func (d *Decoder) arrayLen(c byte) (int, error) {
 }
 
 func decodeStringSliceValue(d *Decoder, v reflect.Value) error {
-	ptr := v.Addr().Convert(sliceStringPtrType).Interface().(*[]string)
+	var ptr *[]string
+	if v.Type() == sliceStringType {
+		ptr = v.Addr().Interface().(*[]string)
+	} else {
+		ptr = v.Addr().Convert(sliceStringPtrType).Interface().(*[]string)
+	}
 	return d.decodeStringSlicePtr(ptr)
 }
 

--- a/encode_map.go
+++ b/encode_map.go
@@ -39,7 +39,12 @@ func encodeMapStringBoolValue(e *Encoder, v reflect.Value) error {
 		return err
 	}
 
-	m := v.Convert(mapStringBoolType).Interface().(map[string]bool)
+	var m map[string]bool
+	if v.Type() == mapStringBoolType {
+		m = v.Interface().(map[string]bool)
+	} else {
+		m = v.Convert(mapStringBoolType).Interface().(map[string]bool)
+	}
 	if e.flags&sortMapKeysFlag != 0 {
 		return e.encodeSortedMapStringBool(m)
 	}
@@ -65,7 +70,12 @@ func encodeMapStringStringValue(e *Encoder, v reflect.Value) error {
 		return err
 	}
 
-	m := v.Convert(mapStringStringType).Interface().(map[string]string)
+	var m map[string]string
+	if v.Type() == mapStringStringType {
+		m = v.Interface().(map[string]string)
+	} else {
+		m = v.Convert(mapStringStringType).Interface().(map[string]string)
+	}
 	if e.flags&sortMapKeysFlag != 0 {
 		return e.encodeSortedMapStringString(m)
 	}
@@ -86,7 +96,12 @@ func encodeMapStringInterfaceValue(e *Encoder, v reflect.Value) error {
 	if v.IsNil() {
 		return e.EncodeNil()
 	}
-	m := v.Convert(mapStringInterfaceType).Interface().(map[string]interface{})
+	var m map[string]interface{}
+	if v.Type() == mapStringInterfaceType {
+		m = v.Interface().(map[string]interface{})
+	} else {
+		m = v.Convert(mapStringInterfaceType).Interface().(map[string]interface{})
+	}
 	if e.flags&sortMapKeysFlag != 0 {
 		return e.EncodeMapSorted(m)
 	}

--- a/encode_slice.go
+++ b/encode_slice.go
@@ -99,7 +99,12 @@ func (e *Encoder) EncodeArrayLen(l int) error {
 }
 
 func encodeStringSliceValue(e *Encoder, v reflect.Value) error {
-	ss := v.Convert(stringSliceType).Interface().([]string)
+	var ss []string
+	if v.Type() == stringSliceType {
+		ss = v.Interface().([]string)
+	} else {
+		ss = v.Convert(stringSliceType).Interface().([]string)
+	}
 	return e.encodeStringSlice(ss)
 }
 


### PR DESCRIPTION
## Summary
- Adds `v.Type() == targetType` fast path before `v.Convert()` in map and slice encode/decode functions
- `Convert` is only needed for named types (e.g., `type M map[string]string`); for exact type matches it's pure overhead
- Applies to `map[string]string`, `map[string]bool`, `map[string]interface{}`, and `[]string` paths

## Benchmark Results
```
StringSlice:         85 ns -> 79 ns  (-7%)
MapStringString:    192 ns -> 176 ns (-8%)
MapStringStringPtr: 217 ns -> 205 ns (-6%)
```

## Test plan
- [x] All existing tests pass (including intern tests with named map types)
- [x] Benchmarks show consistent improvement