### PR TITLE
perf(encode): add map[string]string fast path in Encode() type switch

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -243,6 +243,8 @@ func (e *Encoder) Encode(v interface{}) error {
 		return e.encodeInt64Cond(int64(v))
 	case time.Time:
 		return e.EncodeTime(v)
+	case map[string]string:
+		return e.encodeMapStringString(v)
 	case map[string]interface{}:
 		if e.flags&sortMapKeysFlag != 0 {
 			return e.EncodeMapSorted(v)

--- a/encode_map.go
+++ b/encode_map.go
@@ -93,6 +93,27 @@ func encodeMapStringInterfaceValue(e *Encoder, v reflect.Value) error {
 	return e.EncodeMap(m)
 }
 
+func (e *Encoder) encodeMapStringString(m map[string]string) error {
+	if m == nil {
+		return e.EncodeNil()
+	}
+	if err := e.EncodeMapLen(len(m)); err != nil {
+		return err
+	}
+	if e.flags&sortMapKeysFlag != 0 {
+		return e.encodeSortedMapStringString(m)
+	}
+	for mk, mv := range m {
+		if err := e.EncodeString(mk); err != nil {
+			return err
+		}
+		if err := e.EncodeString(mv); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (e *Encoder) EncodeMap(m map[string]interface{}) error {
 	if m == nil {
 		return e.EncodeNil()


### PR DESCRIPTION
## Summary
- Adds `case map[string]string:` to `Encode()` type switch, bypassing `reflect.ValueOf` + `getEncoder` dispatch
- Adds `encodeMapStringString` method that operates directly on the concrete type

## Benchmark Results
```
MapStringString: 192 ns -> 164 ns (-15%)
```

## Test plan
- [x] All existing tests pass
- [x] Benchmarks show 15% improvement for map[string]string encoding