### PR TITLE
perf(decode): replace goroutine-per-type value pool with sync.Pool

### DIFF
--- a/decode_typgen.go
+++ b/decode_typgen.go
@@ -5,36 +5,18 @@ import (
 	"sync"
 )
 
-var cachedValues struct {
-	m map[reflect.Type]chan reflect.Value
-	sync.RWMutex
-}
+var cachedPools sync.Map // map[reflect.Type]*sync.Pool
 
 func cachedValue(t reflect.Type) reflect.Value {
-	cachedValues.RLock()
-	ch := cachedValues.m[t]
-	cachedValues.RUnlock()
-	if ch != nil {
-		return <-ch
+	v, ok := cachedPools.Load(t)
+	if !ok {
+		v, _ = cachedPools.LoadOrStore(t, &sync.Pool{
+			New: func() interface{} {
+				return reflect.New(t)
+			},
+		})
 	}
-
-	cachedValues.Lock()
-	defer cachedValues.Unlock()
-	if ch = cachedValues.m[t]; ch != nil {
-		return <-ch
-	}
-
-	ch = make(chan reflect.Value, 256)
-	go func() {
-		for {
-			ch <- reflect.New(t)
-		}
-	}()
-	if cachedValues.m == nil {
-		cachedValues.m = make(map[reflect.Type]chan reflect.Value, 8)
-	}
-	cachedValues.m[t] = ch
-	return <-ch
+	return v.(*sync.Pool).Get().(reflect.Value)
 }
 
 func (d *Decoder) newValue(t reflect.Type) reflect.Value {


### PR DESCRIPTION
## Summary
- Replaces `cachedValues` (unbounded goroutine per type + channel buffer of 256) with `sync.Pool` per type stored in `sync.Map`
- Eliminates goroutine leak — the old approach spawned a goroutine for every unique decoded type that ran in an infinite `for { ch <- reflect.New(t) }` loop forever
- Net reduction: -27 lines added, +9 lines = 18 lines fewer

## Details
The old mechanism used `sync.RWMutex` + `map[reflect.Type]chan reflect.Value` with a goroutine per type that pre-generated values into a buffered channel. This leaked goroutines (one per unique type, never cleaned up) and used channel synchronization on the hot path.

The new approach uses `sync.Map` + `sync.Pool` per type. Since decoded values are mutated by the caller and not returned to the pool, `sync.Pool` degrades to `pool.New()` after GC — but this is equivalent to `reflect.New(t)` which is what the non-preallocate path already does.

## Test plan
- [x] All existing tests pass
- [x] Race tests pass (`go test -short -race`)
- [x] No benchmark regressions