### PR TITLE
perf(decode): pool rec buffer in unmarshalValue

### DIFF
--- a/decode_value.go
+++ b/decode_value.go
@@ -5,9 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/vmihailenco/msgpack/v5/msgpcode"
 )
+
+var recBufPool = sync.Pool{
+	New: func() interface{} {
+		b := make([]byte, 0, 64)
+		return &b
+	},
+}
 
 var (
 	interfaceType = reflect.TypeOf((*interface{})(nil)).Elem()
@@ -233,17 +241,29 @@ func decodeCustomValue(d *Decoder, v reflect.Value) error {
 }
 
 func unmarshalValue(d *Decoder, v reflect.Value) error {
-	var b []byte
+	bp := recBufPool.Get().(*[]byte)
+	*bp = (*bp)[:0]
 
-	d.rec = make([]byte, 0, 64)
+	d.rec = *bp
 	if err := d.Skip(); err != nil {
+		d.rec = nil
+		*bp = (*bp)[:0]
+		recBufPool.Put(bp)
 		return err
 	}
-	b = d.rec
+	b := d.rec
 	d.rec = nil
 
 	unmarshaler := v.Interface().(Unmarshaler)
-	return unmarshaler.UnmarshalMsgpack(b)
+	err := unmarshaler.UnmarshalMsgpack(b)
+
+	// Return buffer to pool; drop oversized buffers.
+	if cap(b) <= 4096 {
+		*bp = b
+		recBufPool.Put(bp)
+	}
+
+	return err
 }
 
 // unmarshalBinaryOrTextValue peeks at the wire format to choose between


### PR DESCRIPTION
## Summary
- Pools the `[]byte` recording buffer used by `unmarshalValue` via `sync.Pool`
- Eliminates 1 allocation per `Unmarshaler.UnmarshalMsgpack` decode call
- Oversized buffers (>4KB) are dropped to prevent unbounded pool growth
- `DecodeRaw` is not pooled since the caller owns the returned `RawMessage` slice

## Benchmark (no regression; Unmarshaler alloc savings not measured by existing benchmarks)

| Benchmark | ns/op | B/op | allocs/op |
|-----------|-------|------|-----------|
| StructMarshal | 389 | 1224 | 4 |
| StructUnmarshal | 356 | 48 | 7 |
| MapStringString | 183 | 16 | 4 |
| MapStringInterface | 396 | 402 | 12 |

## Test plan
- [x] `go test -count=1 ./...` — all pass
- [x] `go test -short -race -count=1 -timeout=5m ./...` — no races
- [x] Benchmarks — no regressions