### PR TITLE
perf(decode): inline hasNilCode for byte-slice reader

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -624,6 +624,11 @@ func (d *Decoder) ReadFull(buf []byte) error {
 }
 
 func (d *Decoder) hasNilCode() bool {
+	// Fast path: when decoding from a byte slice, peek directly
+	// to avoid two interface method calls (ReadByte + UnreadByte).
+	if d.s == &d.bsr {
+		return d.bsr.pos < len(d.bsr.data) && d.bsr.data[d.bsr.pos] == msgpcode.Nil
+	}
 	code, err := d.PeekCode()
 	return err == nil && code == msgpcode.Nil
 }


### PR DESCRIPTION
## Summary
- Adds a fast path in `hasNilCode` that peeks directly at the byte-slice reader's underlying data when decoding via `Unmarshal`/`ResetBytes`
- Avoids two interface method calls (`ReadByte` + `UnreadByte`) per nil check, which is called for every pointer field during struct decode

## Benchmark (vs v6 baseline)

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| StructUnmarshal | 356 ns | 349 ns | **-2.0%** |
| StructRoundtrip | 756 ns | 747 ns | **-1.2%** |
| MapStringString | 183 ns | 176 ns | **-3.8%** |
| MapStringStringPtr | 213 ns | 207 ns | **-2.8%** |

## Test plan
- [x] `go test -count=1 ./...` — all pass
- [x] `go test -short -race -count=1 -timeout=5m ./...` — no races
- [x] `env GOOS=linux GOARCH=386 go vet ./...` — cross-platform check
- [x] Benchmarks — improvements across decode paths