### PR TITLE
chore: lower go.mod directive from 1.26 to 1.25 (closes #70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - **encode/decode:** pool and pre-allocate interned-string dict — `SetInternedStringsDictCap(n)` pre-sizes the dict to avoid map rehashing and slice growth; pooled encoders/decoders now reuse dict storage across `Reset()` (cleared in place) instead of discarding it, and `Put*()` drops oversized dicts to keep the pool lean ([#66](https://github.com/Basekick-Labs/msgpack/issues/66))
 - **decode:** hoist `newValue()` allocations out of `decodeTypedMapValue` loop — reuses a single key slot and value slot across all map entries, zeroing between iterations. Takes typed-map decode from 2N `reflect.New()` calls to 2 per map ([#65](https://github.com/Basekick-Labs/msgpack/issues/65)) (BenchmarkLargeMapIntInt **-50% allocs/op**, **-50% B/op**, **-10% ns/op** for 1000-entry `map[int]int`)
 
+### Chores
+
+- Lower `go.mod` directive from 1.26 to 1.25 — preserves drop-in compatibility for downstream users on Go 1.25; CI matrix unchanged (1.25.x, 1.26.x) ([#70](https://github.com/Basekick-Labs/msgpack/issues/70))
+
 ---
 
 ## v6.0.0 (Basekick-Labs fork)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Basekick-Labs/msgpack/v6
 
-go 1.26
+go 1.25
 
 require (
 	github.com/stretchr/testify v1.6.1


### PR DESCRIPTION
## Summary

- Lowers the `go.mod` directive from `1.26` to `1.25` to restore drop-in compatibility for downstream consumers still on Go 1.25 (reported in #70).
- The original bump to 1.26 in 8cb2d99 was a modernization decision, not a code requirement. The codebase only relies on 1.21+ builtins (`min`, `max`, `clear`); no 1.22+ language features (range-over-int, iterators) or 1.26-only stdlib APIs are in use.
- CI matrix in `.github/workflows/build.yml` already covers `1.25.x` and `1.26.x`, so 1.25 support is continuously exercised — no workflow change needed.
- CHANGELOG entry added under `v6.1 (unreleased) > Chores`. The historical v6.0.0 note about the original 1.26 bump is intentionally preserved as accurate history.

Closes #70.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./...` — pass
- [x] `go test -race ./...` — pass
- [x] CI green on both Go 1.25.x and Go 1.26.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)