### PR TITLE
perf: expand Encode() type switch with more common types

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -11,6 +11,35 @@ import (
 	"github.com/Basekick-Labs/msgpack/v6"
 )
 
+func benchmarkEncode(b *testing.B, src interface{}) {
+	enc := msgpack.NewEncoder(ioutil.Discard)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		if err := enc.Encode(src); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncodeInt8(b *testing.B)  { benchmarkEncode(b, int8(-42)) }
+func BenchmarkEncodeInt16(b *testing.B) { benchmarkEncode(b, int16(-3200)) }
+func BenchmarkEncodeInt32(b *testing.B) { benchmarkEncode(b, int32(-320000)) }
+
+func BenchmarkEncodeUint8(b *testing.B)  { benchmarkEncode(b, uint8(200)) }
+func BenchmarkEncodeUint16(b *testing.B) { benchmarkEncode(b, uint16(64000)) }
+func BenchmarkEncodeUint32(b *testing.B) { benchmarkEncode(b, uint32(4000000000)) }
+
+func BenchmarkEncodeStringSlice(b *testing.B) {
+	benchmarkEncode(b, []string{"hello", "world", "foo", "bar"})
+}
+
+func BenchmarkEncodeMapStringBool(b *testing.B) {
+	benchmarkEncode(b, map[string]bool{"hello": true, "world": false})
+}
+
 func BenchmarkDiscard(b *testing.B) {
 	enc := msgpack.NewEncoder(ioutil.Discard)
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -40,6 +40,14 @@ func BenchmarkEncodeMapStringBool(b *testing.B) {
 	benchmarkEncode(b, map[string]bool{"hello": true, "world": false})
 }
 
+// namedInt misses every case in the Encode() type switch, measuring the cost
+// of traversing the full switch and falling through to the reflection path.
+type namedInt int64
+
+func BenchmarkEncodeFallthrough(b *testing.B) {
+	benchmarkEncode(b, namedInt(42))
+}
+
 func BenchmarkDiscard(b *testing.B) {
 	enc := msgpack.NewEncoder(ioutil.Discard)
 

--- a/encode.go
+++ b/encode.go
@@ -284,10 +284,22 @@ func (e *Encoder) Encode(v interface{}) error {
 		return e.EncodeBytes(v)
 	case int:
 		return e.EncodeInt(int64(v))
+	case int8:
+		return e.encodeInt8Cond(v)
+	case int16:
+		return e.encodeInt16Cond(v)
+	case int32:
+		return e.encodeInt32Cond(v)
 	case int64:
 		return e.encodeInt64Cond(v)
 	case uint:
 		return e.EncodeUint(uint64(v))
+	case uint8:
+		return e.encodeUint8Cond(v)
+	case uint16:
+		return e.encodeUint16Cond(v)
+	case uint32:
+		return e.encodeUint32Cond(v)
 	case uint64:
 		return e.encodeUint64Cond(v)
 	case bool:
@@ -302,6 +314,8 @@ func (e *Encoder) Encode(v interface{}) error {
 		return e.EncodeTime(v)
 	case map[string]string:
 		return e.encodeMapStringString(v)
+	case map[string]bool:
+		return e.encodeMapStringBool(v)
 	case map[string]interface{}:
 		if e.flags&sortMapKeysFlag != 0 {
 			return e.EncodeMapSorted(v)
@@ -309,6 +323,8 @@ func (e *Encoder) Encode(v interface{}) error {
 		return e.EncodeMap(v)
 	case []interface{}:
 		return e.encodeInterfaceSlice(v)
+	case []string:
+		return e.encodeStringSlice(v)
 	}
 	return e.EncodeValue(reflect.ValueOf(v))
 }

--- a/encode_map.go
+++ b/encode_map.go
@@ -60,39 +60,18 @@ func encodeMapStringBoolValue(e *Encoder, v reflect.Value) error {
 		return e.EncodeNil()
 	}
 
-	if err := e.EncodeMapLen(v.Len()); err != nil {
-		return err
-	}
-
 	var m map[string]bool
 	if v.Type() == mapStringBoolType {
 		m = v.Interface().(map[string]bool)
 	} else {
 		m = v.Convert(mapStringBoolType).Interface().(map[string]bool)
 	}
-	if e.flags&sortMapKeysFlag != 0 {
-		return e.encodeSortedMapStringBool(m)
-	}
-
-	for mk, mv := range m {
-		if err := e.EncodeString(mk); err != nil {
-			return err
-		}
-		if err := e.EncodeBool(mv); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return e.encodeMapStringBool(m)
 }
 
 func encodeMapStringStringValue(e *Encoder, v reflect.Value) error {
 	if v.IsNil() {
 		return e.EncodeNil()
-	}
-
-	if err := e.EncodeMapLen(v.Len()); err != nil {
-		return err
 	}
 
 	var m map[string]string
@@ -101,20 +80,7 @@ func encodeMapStringStringValue(e *Encoder, v reflect.Value) error {
 	} else {
 		m = v.Convert(mapStringStringType).Interface().(map[string]string)
 	}
-	if e.flags&sortMapKeysFlag != 0 {
-		return e.encodeSortedMapStringString(m)
-	}
-
-	for mk, mv := range m {
-		if err := e.EncodeString(mk); err != nil {
-			return err
-		}
-		if err := e.EncodeString(mv); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return e.encodeMapStringString(m)
 }
 
 func encodeMapStringInterfaceValue(e *Encoder, v reflect.Value) error {

--- a/encode_map.go
+++ b/encode_map.go
@@ -133,6 +133,27 @@ func encodeMapStringInterfaceValue(e *Encoder, v reflect.Value) error {
 	return e.EncodeMap(m)
 }
 
+func (e *Encoder) encodeMapStringBool(m map[string]bool) error {
+	if m == nil {
+		return e.EncodeNil()
+	}
+	if err := e.EncodeMapLen(len(m)); err != nil {
+		return err
+	}
+	if e.flags&sortMapKeysFlag != 0 {
+		return e.encodeSortedMapStringBool(m)
+	}
+	for mk, mv := range m {
+		if err := e.EncodeString(mk); err != nil {
+			return err
+		}
+		if err := e.EncodeBool(mv); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (e *Encoder) encodeMapStringString(m map[string]string) error {
 	if m == nil {
 		return e.EncodeNil()

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -99,6 +99,52 @@ func (t *MsgpackTest) TestMap() {
 	}
 }
 
+func (t *MsgpackTest) TestEncodeTypeSwitchFastPaths() {
+	// Every type fast-pathed in Encode() must produce output byte-identical
+	// to the reflection path (EncodeValue).
+	for _, v := range []interface{}{
+		int8(-42), int8(127), int8(-128),
+		int16(-3200), int16(32767),
+		int32(-320000), int32(2147483647),
+		uint8(0), uint8(200), uint8(255),
+		uint16(64000),
+		uint32(4000000000),
+		[]string{"hello", "world"},
+		[]string{},
+		[]string(nil),
+		map[string]bool{"hello": true},
+		map[string]bool{},
+		map[string]bool(nil),
+	} {
+		var fast, slow bytes.Buffer
+
+		enc := msgpack.NewEncoder(&fast)
+		t.Nil(enc.Encode(v))
+
+		enc = msgpack.NewEncoder(&slow)
+		t.Nil(enc.EncodeValue(reflect.ValueOf(v)))
+
+		t.Equal(slow.Bytes(), fast.Bytes(), fmt.Sprintf("encoding %T(%v)", v, v))
+	}
+}
+
+func (t *MsgpackTest) TestEncodeMapStringBoolSorted() {
+	in := map[string]bool{"c": true, "a": false, "b": true}
+
+	t.enc.SetSortMapKeys(true)
+	t.Nil(t.enc.Encode(in))
+	t.Equal([]byte{
+		0x83,
+		0xa1, 'a', 0xc2,
+		0xa1, 'b', 0xc3,
+		0xa1, 'c', 0xc3,
+	}, t.buf.Bytes())
+
+	var out map[string]bool
+	t.Nil(t.dec.Decode(&out))
+	t.Equal(in, out)
+}
+
 func (t *MsgpackTest) TestStructNil() {
 	var dst *nameStruct
 

--- a/types_test.go
+++ b/types_test.go
@@ -436,6 +436,7 @@ type (
 	sliceByte          []byte
 	sliceString        []string
 	mapStringString    map[string]string
+	mapStringBool      map[string]bool
 	mapStringInterface map[string]interface{}
 )
 
@@ -544,6 +545,9 @@ var (
 		{in: map[string]string(nil), out: new(map[string]string)},
 		{in: map[string]interface{}{"foo": nil}, out: new(map[string]interface{})},
 		{in: mapStringString{"foo": "bar"}, out: new(mapStringString)},
+		{in: map[string]bool{"foo": true, "bar": false}, out: new(map[string]bool)},
+		{in: map[string]bool(nil), out: new(map[string]bool)},
+		{in: mapStringBool{"foo": true}, out: new(mapStringBool)},
 		{in: map[stringAlias]stringAlias{"foo": "bar"}, out: new(map[stringAlias]stringAlias)},
 		{in: mapStringInterface{"foo": "bar"}, out: new(mapStringInterface)},
 		{in: map[stringAlias]interfaceAlias{"foo": "bar"}, out: new(map[stringAlias]interfaceAlias)},


### PR DESCRIPTION
## Summary

Closes #60.

Adds fast paths to the `Encode()` type switch for `int8`/`int16`/`int32`, `uint8`/`uint16`/`uint32`, `[]string`, and `map[string]bool`. Each avoids `reflect.ValueOf` boxing plus a `getEncoder` sync.Map lookup. Also deduplicates `encodeMapStringBoolValue`/`encodeMapStringStringValue` to delegate to the concrete encoders (same pattern as `encodeStringSliceValue`).

## Benchmarks (Apple M3 Max, benchstat, count=8)

| benchmark | before | after | delta |
|---|---|---|---|
| EncodeInt8 | 12.03n | 3.75n | **-68.9%** |
| EncodeInt16 | 12.05n | 3.85n | **-68.0%** |
| EncodeInt32 | 12.58n | 4.29n | **-65.9%** |
| EncodeUint8 | 12.89n | 3.75n | **-70.9%** |
| EncodeUint16 | 12.30n | 3.87n | **-68.6%** |
| EncodeUint32 | 12.57n | 4.30n | **-65.8%** |
| EncodeStringSlice | 38.16n | 26.62n | **-30.2%** |
| EncodeMapStringBool | 65.24n | 49.94n | **-23.5%** |

All p=0.000, zero allocs in both directions.

### No regression on hot/fall-through paths

The larger switch was checked against hot encode types (string, int64, float64, time.Time, bool): all flat-to-marginally-faster (e.g. float64 -0.57%, time.Time -0.58%). `StructMarshal` and `MapStringInterfaceMsgpack` (default/reflection path) also flat. Added `BenchmarkEncodeFallthrough` to track the reflection fall-through cost going forward.

## Testing

- New `TestEncodeTypeSwitchFastPaths`: every fast-pathed type produces byte-identical output to the reflection path (`EncodeValue`), including nil/empty/min/max edge values.
- New `TestEncodeMapStringBoolSorted`: `SetSortMapKeys` honored on the new map fast path, exact byte assertion.
- New typeTests entries for `map[string]bool`, nil, and named `mapStringBool` (Convert path).
- `go test ./...` and `go test -race ./...` pass.

Internal 4-agent review pass (correctness/security/quality/perf) completed; flagged switch-ordering concern measured and disproven, duplication finding fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)