### PR TITLE
perf: configurable pool buffer retention limit via SetPoolBufferLimit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Performance
 
 - **decode:** reuse caller-supplied destination map for `map[string]interface{}` — `Decode(&m)`/`Unmarshal(data, &m)` with a non-nil `m` now decodes into the existing map (entries merged) instead of replacing it with a fresh allocation, matching the long-standing `map[string]string` behavior. Applies to all decode paths for the type: the `Decode()` fast path, struct fields, and named map types. Callers that `clear(m)` and reuse the destination get zero map allocations per decode ([#61](https://github.com/Basekick-Labs/msgpack/issues/61)) (decoding a 4-key map into a reused destination, v6 vs this change on the same benchmark: **-22.9% ns/op**, **-80.8% B/op**, 12 → 10 allocs/op). Note: this diverges from upstream, which replaces a non-nil `map[string]interface{}` destination; pass a nil map to keep replace semantics.
+- **encode/decode:** configurable pooled buffer retention limit via `SetPoolBufferLimit(n)` — workloads with consistently large messages can raise the default 32 KiB threshold so pooled encoders/decoders keep their grown buffers across uses instead of re-allocating ([#62](https://github.com/Basekick-Labs/msgpack/issues/62)) (100KB payloads with a 256 KiB limit: MarshalAppend **-50% ns/op**, **3→1 allocs/op**; stream decode **-37% ns/op**, **3→1 allocs/op**)
 
 ---
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,6 +20,27 @@ func benchmarkEncode(b *testing.B, src interface{}) {
 
 	for i := 0; i < b.N; i++ {
 		if err := enc.Encode(src); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Large-payload benchmarks for the pooled encoder/decoder buffer limit
+// (issue #62). With the default 32KiB limit, every PutEncoder/PutDecoder
+// drops the grown buffer and the next pooled use must re-grow it; raising
+// the limit retains the buffer across pool round-trips.
+
+func benchmarkMarshalAppendLarge(b *testing.B, n int) {
+	payload := make([]byte, n)
+	buf := make([]byte, 0, n+16)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var err error
+		buf, err = msgpack.MarshalAppend(buf[:0], payload)
+		if err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -46,6 +68,50 @@ type namedInt int64
 
 func BenchmarkEncodeFallthrough(b *testing.B) {
 	benchmarkEncode(b, namedInt(42))
+}
+
+func BenchmarkMarshalAppendLarge100KB(b *testing.B) {
+	b.Run("pool-limit-default", func(b *testing.B) {
+		benchmarkMarshalAppendLarge(b, 100<<10)
+	})
+	b.Run("pool-limit-256k", func(b *testing.B) {
+		msgpack.SetPoolBufferLimit(256 << 10)
+		defer msgpack.SetPoolBufferLimit(0)
+		benchmarkMarshalAppendLarge(b, 100<<10)
+	})
+}
+
+func benchmarkDecodeLargeStream(b *testing.B, n int) {
+	data, err := msgpack.Marshal(strings.Repeat("x", n))
+	if err != nil {
+		b.Fatal(err)
+	}
+	rd := bytes.NewReader(data)
+	var out string
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		rd.Reset(data)
+		dec := msgpack.GetDecoder()
+		dec.Reset(rd)
+		if err := dec.Decode(&out); err != nil {
+			b.Fatal(err)
+		}
+		msgpack.PutDecoder(dec)
+	}
+}
+
+func BenchmarkDecodeLargeStream100KB(b *testing.B) {
+	b.Run("pool-limit-default", func(b *testing.B) {
+		benchmarkDecodeLargeStream(b, 100<<10)
+	})
+	b.Run("pool-limit-256k", func(b *testing.B) {
+		msgpack.SetPoolBufferLimit(256 << 10)
+		defer msgpack.SetPoolBufferLimit(0)
+		benchmarkDecodeLargeStream(b, 100<<10)
+	})
 }
 
 func BenchmarkDiscard(b *testing.B) {

--- a/decode.go
+++ b/decode.go
@@ -48,7 +48,7 @@ func PutDecoder(dec *Decoder) {
 	dec.bsr.data = nil
 	// Keep buf capacity for reuse, but drop oversized buffers to prevent
 	// the pool from retaining memory from large decode operations.
-	if cap(dec.buf) > 32*1024 {
+	if poolBufOversized(cap(dec.buf)) {
 		dec.buf = nil
 	} else if dec.buf != nil {
 		dec.buf = dec.buf[:0]

--- a/encode.go
+++ b/encode.go
@@ -55,7 +55,7 @@ func GetEncoder() *Encoder {
 func PutEncoder(enc *Encoder) {
 	enc.w = nil
 	// Keep wbuf capacity for reuse, but drop oversized buffers.
-	if cap(enc.wbuf) > 32*1024 {
+	if poolBufOversized(cap(enc.wbuf)) {
 		enc.wbuf = nil
 	}
 	// Drop the interned-string dict if we own it and it grew large, so pool

--- a/pool.go
+++ b/pool.go
@@ -1,0 +1,49 @@
+package msgpack
+
+import "sync/atomic"
+
+// defaultPoolBufferLimit is the default maximum capacity, in bytes, of
+// internal buffers retained by pooled encoders and decoders.
+const defaultPoolBufferLimit = 32 * 1024
+
+// poolBufferLimit holds the configured limit. Zero means "use the default";
+// it is read atomically so SetPoolBufferLimit is safe to call concurrently
+// with PutEncoder/PutDecoder.
+var poolBufferLimit atomic.Int64
+
+// SetPoolBufferLimit sets the maximum capacity, in bytes, of internal
+// buffers retained by pooled encoders and decoders (GetEncoder/PutEncoder,
+// GetDecoder/PutDecoder, and the package-level Marshal/MarshalAppend/
+// Unmarshal helpers that use them). Buffers whose capacity exceeds the
+// limit are dropped when the encoder or decoder is returned to the pool,
+// so one-off large operations don't pin memory.
+//
+// The default is 32 KiB. Workloads that consistently encode or decode
+// larger payloads can raise the limit to avoid re-growing buffers on every
+// pooled use. Values below the default are clamped to the default;
+// n <= 0 restores the default.
+func SetPoolBufferLimit(n int) {
+	if n <= 0 {
+		poolBufferLimit.Store(0)
+		return
+	}
+	if n < defaultPoolBufferLimit {
+		n = defaultPoolBufferLimit
+	}
+	poolBufferLimit.Store(int64(n))
+}
+
+func getPoolBufferLimit() int {
+	if n := poolBufferLimit.Load(); n > 0 {
+		return int(n)
+	}
+	return defaultPoolBufferLimit
+}
+
+// poolBufOversized reports whether a pooled buffer of capacity c should be
+// dropped rather than retained. The constant default check comes first so
+// the common small-buffer case never pays for the atomic load; the
+// configured limit is never below the default.
+func poolBufOversized(c int) bool {
+	return c > defaultPoolBufferLimit && c > getPoolBufferLimit()
+}

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,0 +1,80 @@
+package msgpack
+
+import "testing"
+
+// These tests live in the msgpack package (not msgpack_test) because they
+// inspect the unexported wbuf/buf fields to verify pool retention behavior.
+// They rely on sync.Pool returning the just-Put item on the same goroutine,
+// which holds absent a GC between Put and Get.
+
+func TestPoolBufferLimitEncoder(t *testing.T) {
+	const big = 100 * 1024
+
+	// Default limit: an oversized wbuf is dropped on Put.
+	enc := GetEncoder()
+	enc.wbuf = make([]byte, big)
+	PutEncoder(enc)
+	enc = GetEncoder()
+	if cap(enc.wbuf) > defaultPoolBufferLimit {
+		t.Fatalf("wbuf cap=%d retained above default limit", cap(enc.wbuf))
+	}
+	PutEncoder(enc)
+
+	// Raised limit: the same buffer is retained.
+	SetPoolBufferLimit(256 * 1024)
+	defer SetPoolBufferLimit(0)
+
+	enc = GetEncoder()
+	enc.wbuf = make([]byte, big)
+	PutEncoder(enc)
+	enc = GetEncoder()
+	if cap(enc.wbuf) < big {
+		t.Fatalf("wbuf cap=%d, want >= %d retained under raised limit", cap(enc.wbuf), big)
+	}
+	PutEncoder(enc)
+}
+
+func TestPoolBufferLimitDecoder(t *testing.T) {
+	const big = 100 * 1024
+
+	dec := GetDecoder()
+	dec.buf = make([]byte, big)
+	PutDecoder(dec)
+	dec = GetDecoder()
+	if cap(dec.buf) > defaultPoolBufferLimit {
+		t.Fatalf("buf cap=%d retained above default limit", cap(dec.buf))
+	}
+	PutDecoder(dec)
+
+	SetPoolBufferLimit(256 * 1024)
+	defer SetPoolBufferLimit(0)
+
+	dec = GetDecoder()
+	dec.buf = make([]byte, big)
+	PutDecoder(dec)
+	dec = GetDecoder()
+	if cap(dec.buf) < big {
+		t.Fatalf("buf cap=%d, want >= %d retained under raised limit", cap(dec.buf), big)
+	}
+	PutDecoder(dec)
+}
+
+func TestSetPoolBufferLimitClamp(t *testing.T) {
+	SetPoolBufferLimit(-1)
+	if got := getPoolBufferLimit(); got != defaultPoolBufferLimit {
+		t.Fatalf("limit=%d after SetPoolBufferLimit(-1), want default %d", got, defaultPoolBufferLimit)
+	}
+	SetPoolBufferLimit(64 * 1024)
+	if got := getPoolBufferLimit(); got != 64*1024 {
+		t.Fatalf("limit=%d, want %d", got, 64*1024)
+	}
+	// Values below the default are clamped up to the default.
+	SetPoolBufferLimit(1024)
+	if got := getPoolBufferLimit(); got != defaultPoolBufferLimit {
+		t.Fatalf("limit=%d after SetPoolBufferLimit(1024), want clamped default %d", got, defaultPoolBufferLimit)
+	}
+	SetPoolBufferLimit(0)
+	if got := getPoolBufferLimit(); got != defaultPoolBufferLimit {
+		t.Fatalf("limit=%d after reset, want default %d", got, defaultPoolBufferLimit)
+	}
+}

--- a/pool_test.go
+++ b/pool_test.go
@@ -3,33 +3,64 @@ package msgpack
 import "testing"
 
 // These tests live in the msgpack package (not msgpack_test) because they
-// inspect the unexported wbuf/buf fields to verify pool retention behavior.
-// They rely on sync.Pool returning the just-Put item on the same goroutine,
-// which holds absent a GC between Put and Get.
+// inspect the unexported wbuf/buf fields and the unexported retention
+// predicate.
+//
+// Retention behavior is asserted through poolBufOversized rather than
+// through Get/Put round-trips: sync.Pool may drop a Put item at any time
+// (GC, or a Get on a different P), so "the big buffer came back" is not a
+// property a test can rely on. The Get/Put tests below assert only the
+// direction that stays true regardless of pool behavior — an oversized
+// buffer is never handed back.
+
+func TestPoolBufOversized(t *testing.T) {
+	const big = 100 * 1024
+
+	tests := []struct {
+		name  string
+		limit int // 0 means "leave at default"
+		cap   int
+		want  bool
+	}{
+		{name: "default/under", cap: 16 * 1024, want: false},
+		{name: "default/at", cap: defaultPoolBufferLimit, want: false},
+		{name: "default/over", cap: defaultPoolBufferLimit + 1, want: true},
+		{name: "default/big", cap: big, want: true},
+
+		{name: "raised/under", limit: 256 * 1024, cap: big, want: false},
+		{name: "raised/at", limit: 256 * 1024, cap: 256 * 1024, want: false},
+		{name: "raised/over", limit: 256 * 1024, cap: 256*1024 + 1, want: true},
+
+		// A limit below the default clamps up, so the default still governs.
+		{name: "clamped/under", limit: 1024, cap: 16 * 1024, want: false},
+		{name: "clamped/over", limit: 1024, cap: big, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.limit != 0 {
+				SetPoolBufferLimit(tt.limit)
+				defer SetPoolBufferLimit(0)
+			}
+			if got := poolBufOversized(tt.cap); got != tt.want {
+				t.Fatalf("poolBufOversized(%d) with limit %d = %v, want %v",
+					tt.cap, getPoolBufferLimit(), got, tt.want)
+			}
+		})
+	}
+}
 
 func TestPoolBufferLimitEncoder(t *testing.T) {
 	const big = 100 * 1024
 
-	// Default limit: an oversized wbuf is dropped on Put.
+	// Under the default limit an oversized wbuf must never be handed back.
+	// (A fresh encoder from the pool is also fine — both satisfy this.)
 	enc := GetEncoder()
 	enc.wbuf = make([]byte, big)
 	PutEncoder(enc)
 	enc = GetEncoder()
 	if cap(enc.wbuf) > defaultPoolBufferLimit {
-		t.Fatalf("wbuf cap=%d retained above default limit", cap(enc.wbuf))
-	}
-	PutEncoder(enc)
-
-	// Raised limit: the same buffer is retained.
-	SetPoolBufferLimit(256 * 1024)
-	defer SetPoolBufferLimit(0)
-
-	enc = GetEncoder()
-	enc.wbuf = make([]byte, big)
-	PutEncoder(enc)
-	enc = GetEncoder()
-	if cap(enc.wbuf) < big {
-		t.Fatalf("wbuf cap=%d, want >= %d retained under raised limit", cap(enc.wbuf), big)
+		t.Fatalf("wbuf cap=%d retained above default limit %d", cap(enc.wbuf), defaultPoolBufferLimit)
 	}
 	PutEncoder(enc)
 }
@@ -42,19 +73,7 @@ func TestPoolBufferLimitDecoder(t *testing.T) {
 	PutDecoder(dec)
 	dec = GetDecoder()
 	if cap(dec.buf) > defaultPoolBufferLimit {
-		t.Fatalf("buf cap=%d retained above default limit", cap(dec.buf))
-	}
-	PutDecoder(dec)
-
-	SetPoolBufferLimit(256 * 1024)
-	defer SetPoolBufferLimit(0)
-
-	dec = GetDecoder()
-	dec.buf = make([]byte, big)
-	PutDecoder(dec)
-	dec = GetDecoder()
-	if cap(dec.buf) < big {
-		t.Fatalf("buf cap=%d, want >= %d retained under raised limit", cap(dec.buf), big)
+		t.Fatalf("buf cap=%d retained above default limit %d", cap(dec.buf), defaultPoolBufferLimit)
 	}
 	PutDecoder(dec)
 }


### PR DESCRIPTION
## Summary

Closes #62.

`PutEncoder`/`PutDecoder` drop internal buffers above 32KiB, so workloads with consistently larger messages re-grow the buffer on every pooled use. This adds `SetPoolBufferLimit(n)` to raise the retention limit. Of the three options in the issue, the configurable limit was chosen over (1) raising the default — which would silently change memory retention for all users — and (3) adaptive sizing — which adds racy bookkeeping for marginal benefit.

Design notes:
- Default (32 KiB) unchanged. Values below the default clamp to it; `n <= 0` restores it.
- Limit stored in an `atomic.Int64`; the Put path checks the constant default first (`poolBufOversized`), so small buffers — the common case — never pay for the atomic load. Verified inlinable.
- Applied to both encoder `wbuf` and decoder `buf`, per the issue.

## Benchmarks (Apple M3 Max, benchstat, count=8)

100KB payloads, limit raised to 256 KiB vs default:

| benchmark | default limit | 256k limit | delta |
|---|---|---|---|
| MarshalAppendLarge100KB | 9.31µs, 104KiB, 3 allocs | 4.61µs, 24B, 1 alloc | **-50% ns/op** |
| DecodeLargeStream100KB | 16.14µs, 208KiB, 3 allocs | 10.23µs, 104KiB, 1 alloc | **-37% ns/op** |

No regression at default settings vs v6 (the atomic is not touched for small buffers):

| benchmark | v6 | branch | delta |
|---|---|---|---|
| StructMarshal | 368.5n | 363.6n | -1.33% |
| StructUnmarshal | 338.8n | 338.9n | ~ |

## Testing

- `pool_test.go` (first internal `package msgpack` test file — needed to inspect unexported `wbuf`/`buf`): retention under raised limit, dropping under default, clamping behavior.
- `go test ./...` and `go test -race ./...` pass.
- Internal review pass (correctness+security, quality+perf) completed; only finding was the missing CHANGELOG entry, fixed in the follow-up commit.