### PR TITLE
fix: clamp DecodeUntypedMap allocation at maxMapSize

### DIFF
--- a/decode_map.go
+++ b/decode_map.go
@@ -250,7 +250,12 @@ func (d *Decoder) DecodeUntypedMap() (map[interface{}]interface{}, error) {
 		return nil, nil
 	}
 
-	m := make(map[interface{}]interface{}, n)
+	ln := n
+	if d.flags&disableAllocLimitFlag == 0 {
+		ln = min(ln, maxMapSize)
+	}
+
+	m := make(map[interface{}]interface{}, ln)
 
 	for i := 0; i < n; i++ {
 		mk, err := d.decodeInterfaceCond()

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -75,6 +75,26 @@ func (t *MsgpackTest) TestLargeString() {
 	t.Equal(dst, src)
 }
 
+func (t *MsgpackTest) TestDecodeUntypedMapHugeDeclaredLen() {
+	// A map32 header declaring ~4G entries with no payload: the map size
+	// hint must be clamped at maxMapSize before allocation (with the old
+	// code this allocated a multi-GB map upfront), then fail decoding the
+	// first key.
+	data := []byte{0xdf, 0xff, 0xff, 0xff, 0xff}
+	dec := msgpack.NewDecoder(bytes.NewReader(data))
+	_, err := dec.DecodeUntypedMap()
+	t.NotNil(err)
+}
+
+func (t *MsgpackTest) TestDecodeUntypedMap() {
+	in := map[interface{}]interface{}{int8(1): "one", "two": int8(2)}
+	t.Nil(t.enc.Encode(in))
+
+	out, err := t.dec.DecodeUntypedMap()
+	t.Nil(err)
+	t.Equal(in, out)
+}
+
 func (t *MsgpackTest) TestSliceOfStructs() {
 	in := []*nameStruct{{"hello"}}
 	var out []*nameStruct

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -76,14 +77,33 @@ func (t *MsgpackTest) TestLargeString() {
 }
 
 func (t *MsgpackTest) TestDecodeUntypedMapHugeDeclaredLen() {
-	// A map32 header declaring ~4G entries with no payload: the map size
+	// A map32 header declaring ~2G entries with no payload: the map size
 	// hint must be clamped at maxMapSize before allocation (with the old
 	// code this allocated a multi-GB map upfront), then fail decoding the
 	// first key.
-	data := []byte{0xdf, 0xff, 0xff, 0xff, 0xff}
+	//
+	// 0x7fffffff rather than 0xffffffff: the latter is now rejected by the
+	// int-overflow check on 32-bit builds before reaching the clamp, so it
+	// would pass for the wrong reason. This value fits in an int on every
+	// platform and exercises the clamp itself.
+	data := []byte{0xdf, 0x7f, 0xff, 0xff, 0xff}
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
 	dec := msgpack.NewDecoder(bytes.NewReader(data))
 	_, err := dec.DecodeUntypedMap()
 	t.NotNil(err)
+
+	runtime.ReadMemStats(&after)
+	// The clamp caps the hint at maxMapSize (1M entries). Without it the
+	// declared ~2G entries are allocated upfront -- hundreds of MB and tens
+	// of seconds. Allow generous headroom while still failing loudly if the
+	// clamp is removed.
+	if alloc := after.TotalAlloc - before.TotalAlloc; alloc > 256<<20 {
+		t.Failf("allocation not clamped", "decode allocated %d MiB, want < 256 MiB", alloc>>20)
+	}
 }
 
 func (t *MsgpackTest) TestDecodeUntypedMap() {


### PR DESCRIPTION
## Summary

`DecodeUntypedMap` allocated `map[interface{}]interface{}` with the attacker-declared capacity — the only map decode path missing the `maxMapSize` clamp (`decodeMapValue`, `decodeMapStringInterfaceN`, and `decodeTypedMapN` all have it). A `map32` header declaring ~4G entries forced a multi-GB upfront map allocation before any payload was read. Found by the internal security review pass on #75.

The fix mirrors the sibling paths exactly: clamp the size hint at `maxMapSize` (1M) unless `DisableAllocLimit(true)` is set. The map still grows to the real size if the payload genuinely contains more entries.

## Testing

- `TestDecodeUntypedMapHugeDeclaredLen`: map32 declaring ~4G entries fails fast (previously attempted a multi-GB allocation).
- `TestDecodeUntypedMap`: round-trip coverage for the path (it had none).
- `go test ./...` and `go test -race ./...` pass.

No benchmark changes: the clamp is one branch on a cold path (map header decode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)