### PR TITLE
perf: reuse caller-supplied destination map in map[string]interface{} decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Performance
 
-- **decode:** reuse caller-supplied destination map for `map[string]interface{}` — `Decode(&m)`/`Unmarshal(data, &m)` with a non-nil `m` now decodes into the existing map (entries merged) instead of replacing it with a fresh allocation, matching the long-standing `map[string]string` behavior. Callers that `clear(m)` and reuse the destination get zero map allocations per decode ([#61](https://github.com/Basekick-Labs/msgpack/issues/61)) (reused-destination decode **-22.9% ns/op**, **-80.8% B/op**). Note: this diverges from upstream, which replaces a non-nil `map[string]interface{}` destination; pass a nil map to keep replace semantics.
+- **decode:** reuse caller-supplied destination map for `map[string]interface{}` — `Decode(&m)`/`Unmarshal(data, &m)` with a non-nil `m` now decodes into the existing map (entries merged) instead of replacing it with a fresh allocation, matching the long-standing `map[string]string` behavior. Applies to all decode paths for the type: the `Decode()` fast path, struct fields, and named map types. Callers that `clear(m)` and reuse the destination get zero map allocations per decode ([#61](https://github.com/Basekick-Labs/msgpack/issues/61)) (decoding a 4-key map into a reused destination, v6 vs this change on the same benchmark: **-22.9% ns/op**, **-80.8% B/op**, 12 → 10 allocs/op). Note: this diverges from upstream, which replaces a non-nil `map[string]interface{}` destination; pass a nil map to keep replace semantics.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Performance
+
+- **decode:** reuse caller-supplied destination map for `map[string]interface{}` — `Decode(&m)`/`Unmarshal(data, &m)` with a non-nil `m` now decodes into the existing map (entries merged) instead of replacing it with a fresh allocation, matching the long-standing `map[string]string` behavior. Callers that `clear(m)` and reuse the destination get zero map allocations per decode ([#61](https://github.com/Basekick-Labs/msgpack/issues/61)) (reused-destination decode **-22.9% ns/op**, **-80.8% B/op**). Note: this diverges from upstream, which replaces a non-nil `map[string]interface{}` destination; pass a nil map to keep replace semantics.
+
+---
+
 ## v6.1.0 (2026-04-27)
 
 ### Performance

--- a/bench_test.go
+++ b/bench_test.go
@@ -209,6 +209,32 @@ func BenchmarkMapStringInterfaceMsgpack(b *testing.B) {
 	benchmarkEncodeDecode(b, src, &dst)
 }
 
+// Decode into a reused destination map (issue #61): the caller clears and
+// re-passes the same map, so the decoder allocates no map per iteration.
+func BenchmarkUnmarshalMapStringInterfaceReuse(b *testing.B) {
+	src := map[string]interface{}{
+		"hello": "world",
+		"foo":   "bar",
+		"one":   int64(1111111),
+		"two":   int64(2222222),
+	}
+	data, err := msgpack.Marshal(src)
+	if err != nil {
+		b.Fatal(err)
+	}
+	dst := make(map[string]interface{}, len(src))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		clear(dst)
+		if err := msgpack.Unmarshal(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func BenchmarkMapStringInterfaceJSON(b *testing.B) {
 	src := map[string]interface{}{
 		"hello": "world",

--- a/decode_map.go
+++ b/decode_map.go
@@ -168,12 +168,41 @@ func decodeMapStringInterfaceValue(d *Decoder, v reflect.Value) error {
 	return d.decodeMapStringInterfacePtr(ptr)
 }
 
+// decodeMapStringInterfacePtr decodes into an existing map when the caller
+// supplies one (entries are merged in, matching decodeMapStringStringPtr),
+// avoiding a map allocation per decode for callers that reuse destinations.
 func (d *Decoder) decodeMapStringInterfacePtr(ptr *map[string]interface{}) error {
-	m, err := d.DecodeMap()
+	size, err := d.DecodeMapLen()
 	if err != nil {
 		return err
 	}
-	*ptr = m
+	if size == -1 {
+		*ptr = nil
+		return nil
+	}
+
+	m := *ptr
+	if m == nil {
+		ln := size
+		if d.flags&disableAllocLimitFlag == 0 {
+			ln = min(size, maxMapSize)
+		}
+		*ptr = make(map[string]interface{}, ln)
+		m = *ptr
+	}
+
+	for i := 0; i < size; i++ {
+		mk, err := d.DecodeString()
+		if err != nil {
+			return err
+		}
+		mv, err := d.decodeInterfaceCond()
+		if err != nil {
+			return err
+		}
+		m[mk] = mv
+	}
+
 	return nil
 }
 

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -169,6 +169,27 @@ func (t *MsgpackTest) TestMapStringInterfaceReuse() {
 	dst = nil
 	t.Nil(t.dec.Decode(&dst))
 	t.Equal(in, dst)
+
+	// An empty msgpack map leaves a pre-populated destination untouched.
+	t.Nil(t.enc.Encode(map[string]interface{}{}))
+	dst = map[string]interface{}{"existing": true}
+	t.Nil(t.dec.Decode(&dst))
+	t.Equal(map[string]interface{}{"existing": true}, dst)
+}
+
+func (t *MsgpackTest) TestMapStringInterfaceStructFieldReuse() {
+	// Struct fields of type map[string]interface{} get the same merge
+	// semantics as map[string]string fields always had: a pre-populated
+	// field map is decoded into, not replaced.
+	type withMap struct {
+		Data map[string]interface{}
+	}
+
+	t.Nil(t.enc.Encode(withMap{Data: map[string]interface{}{"new": "value"}}))
+
+	out := withMap{Data: map[string]interface{}{"existing": true}}
+	t.Nil(t.dec.Decode(&out))
+	t.Equal(map[string]interface{}{"existing": true, "new": "value"}, out.Data)
 }
 
 func (t *MsgpackTest) TestStructNil() {

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -145,6 +145,32 @@ func (t *MsgpackTest) TestEncodeMapStringBoolSorted() {
 	t.Equal(in, out)
 }
 
+func (t *MsgpackTest) TestMapStringInterfaceReuse() {
+	in := map[string]interface{}{"hello": "world", "n": int8(1)}
+	t.Nil(t.enc.Encode(in))
+
+	// A caller-supplied map is decoded into in place (entries merged),
+	// matching the map[string]string behavior.
+	dst := map[string]interface{}{"existing": true, "hello": "stale"}
+	t.Nil(t.dec.Decode(&dst))
+	t.Equal(map[string]interface{}{
+		"existing": true, // retained
+		"hello":    "world",
+		"n":        int8(1),
+	}, dst)
+
+	// msgpack nil still resets the destination to nil.
+	t.Nil(t.enc.Encode(map[string]interface{}(nil)))
+	t.Nil(t.dec.Decode(&dst))
+	t.Nil(dst)
+
+	// And a nil destination map is allocated as before.
+	t.Nil(t.enc.Encode(in))
+	dst = nil
+	t.Nil(t.dec.Decode(&dst))
+	t.Equal(in, dst)
+}
+
 func (t *MsgpackTest) TestStructNil() {
 	var dst *nameStruct
 


### PR DESCRIPTION
## Summary

Closes #61 (the safe subset).

`decodeMapStringInterfacePtr` allocated a fresh map via `DecodeMap()` even when the caller passed a non-nil destination — unlike the `map[string]string` path, which has always decoded into an existing map. This mirrors that behavior: entries merge into the caller's map, msgpack `nil` still sets it to nil, and a nil destination allocates as before (with the `maxMapSize` clamp).

Callers that reuse a destination (`clear(m); Unmarshal(data, &m)`) — e.g. a decode hot loop in Arc ingest — now get **zero map allocations per decode**.

### Why not pooling (what the issue proposed first)

`sync.Pool`-ing decoded maps is unsound: the caller retains the returned map, so pooling requires an explicit return API (the issue's own notes flag this, and it's the same ownership hazard class as PR #68/issue #66). Destination reuse delivers the allocation win with no ownership hazard. The issue's alternative proposal (`UnmarshalReuse`-style reuse of existing maps in `v`) is exactly what this implements, without a new API.

### Behavior change (documented in CHANGELOG)

For a **non-nil** `map[string]interface{}` destination, decode now merges instead of replaces — diverging from upstream but consistent with the fork's (and upstream's) existing `map[string]string` semantics. Applies to the `Decode()` fast path, struct fields, and named map types. Pass a nil map to keep replace semantics.

## Benchmarks (Apple M3 Max, benchstat, count=6, identical benchmark on both sides)

Decoding a 4-key map into a reused destination:

| | v6 | this PR | delta |
|---|---|---|---|
| ns/op | 256.9n | 198.2n | **-22.9%** |
| B/op | 416 | 80 | **-80.8%** |
| allocs/op | 12 | 10 | **-16.7%** |

Nil-destination path: one extra branch, no measurable change.

## Testing

- `TestMapStringInterfaceReuse`: merge into pre-populated dst, msgpack nil → nil, nil dst allocates, empty map leaves pre-populated dst untouched.
- `TestMapStringInterfaceStructFieldReuse`: struct-field merge semantics.
- `go test ./...` and `go test -race ./...` pass.
- Internal review pass (correctness+compat, quality+perf+security) completed; all findings addressed in the follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)